### PR TITLE
Matching new []s with delete

### DIFF
--- a/ABItype.cpp
+++ b/ABItype.cpp
@@ -90,7 +90,7 @@ void ABItype::parse ( wxString filename )
         nrecords-- ;
         }
 
-	delete t ;
+	delete [] t ;
     }
     
 /** \brief Deterimnes the position of the "ABIF" key

--- a/CloneManager.cpp
+++ b/CloneManager.cpp
@@ -62,7 +62,7 @@ void TCloneManager::load ( wxString file )
 	
 	if ( t[0] != 26 || t[1] != 'S' || t[2] != 'E' || t[3] != 'S' )
 	{
-		delete t ;
+		delete [] t ;
 		return ;
 	}
 	
@@ -104,7 +104,7 @@ void TCloneManager::load ( wxString file )
 	
 	_v.push_back ( v ) ;
 	_success = true ;
-	delete t ;
+	delete [] t ;
 }
 
 int TCloneManager::countVectors ()

--- a/GenBank.cpp
+++ b/GenBank.cpp
@@ -61,7 +61,7 @@ void TGenBank::load ( wxString s )
            d = c+1 ;
            }    
         }    
-    delete t ;
+    delete [] t ;
     mylog ( "-GenBank import" , "file added" ) ;
     
     parseLines () ; // Calling parser

--- a/PrimerDesign.cpp
+++ b/PrimerDesign.cpp
@@ -178,7 +178,7 @@ void TPrimerDesign::OnImportPrimer ( wxCommandEvent &ev )
                             
     if ( cbl.GetCount() <= 2 ) scd.CheckAll () ;
     int res = scd.ShowModal() ;
-    delete sl ;
+    delete [] sl ;
     if ( res != wxID_OK ) return ;
     
     for ( a = 0 ; a < cbl.GetCount() ; a++ )

--- a/SendHTTP.cpp
+++ b/SendHTTP.cpp
@@ -89,7 +89,7 @@ wxString myExternal::getTextLocal ( wxString url )
 	in.Read ( c , l ) ;
 	in.Close() ;
 	wxString ret = wxString ( c , wxConvUTF8 ) ;
-	delete c ;
+	delete [] c ;
 	return ret ;
 	}
      

--- a/TClone.cpp
+++ b/TClone.cpp
@@ -55,7 +55,7 @@ void TClone::loadEnzymeList ( TStorage *st , wxString filename )
      
      vr.push_back ( r ) ;
 	 }
-	delete t ;
+	delete [] t ;
 
 	for ( i = 0 ; i < vr.size() ; i++ )
 	 {
@@ -184,7 +184,7 @@ void TClone::load ( wxString s )
 	
 	wxArrayString v ;
 	parseLines ( v , t , l ) ;
-	delete t ;
+	delete [] t ;
 
 	int i ;
 	success = true ;

--- a/TPhylip.cpp
+++ b/TPhylip.cpp
@@ -307,7 +307,7 @@ wxString TPhylip::runapp ( wxString app , const wxString s )
 	outtree.Close () ;
 	n[l] = 0 ;
 	wxString result ( n , wxConvUTF8 ) ;
-	delete n ;
+	delete [] n ;
 	
 //	result = "(3:0.23647,(4:0.12270,2:0.00296):0.29673,1:0.65529);(4:0.12270,2:0.00296);" ; // Test
 


### PR DESCRIPTION
I today compiled GENtle on my Mac with the clang++ it ships and was pointed to those missing []s in the corresponding deletes of what was allocated as an array.